### PR TITLE
Fixed render bug at top and bottom edges

### DIFF
--- a/src/main.java
+++ b/src/main.java
@@ -90,9 +90,9 @@ public class main extends BasicGameState implements Game{
 			
 			int blockSize = terrain.grid;
 			int rowCount = terrain.xGen / blockSize;
-
-			int startY =  (Math.round(player.mapY / blockSize))* (rowCount);          
-			int endY = (Math.round((player.mapY + screenHeight) / blockSize))* (rowCount);
+			
+			int startY =  (int) ((Math.floor(player.mapY / blockSize))* (rowCount));          
+			int endY = (int) ((Math.ceil((player.mapY + screenHeight) / blockSize))* (rowCount));
 			
 			if(startY < 0) startY = 0;
 			if(endY > terrain.rects.length) endY = terrain.rects.length;


### PR DESCRIPTION
Now uses floor and ceil instead of round to determine where the rendering starts and stops. Rows no longer disappear at the top/bottom edges when falling or jumping.